### PR TITLE
HYS-1142 Document upload consumes optional externalData

### DIFF
--- a/docs/openapi/code-samples/projects@{projectId}/upload.txt
+++ b/docs/openapi/code-samples/projects@{projectId}/upload.txt
@@ -1,4 +1,5 @@
 curl -X POST \
   --form 'file=@"scan_invoice.pdf"' \
+  --form 'externalData="{\"yourField1\":\"yourValue1\"}"'\
   -H "Authorization: Basic YWRtaW46c2VjcmV0" \
   https://api.studio.hypatos.ai/v1/projects/12345/documents/upload

--- a/docs/openapi/components/requestBodies/upload.yaml
+++ b/docs/openapi/components/requestBodies/upload.yaml
@@ -3,8 +3,12 @@ required: true
 content:
   multipart/form-data:
     schema:
+      type: object
+      required: [file]
       properties:
         file:
           type: string
           description: A PDF, TIFF, JPEG or PNG file to upload
-          required: true
+        externalData:
+          type: string
+          description: Document external data, including any externalId that will be used for mapping


### PR DESCRIPTION
Upload endpoint now accepts optional `externalData`:
https://hypatos.atlassian.net/browse/HYS-921