### PR TITLE
Fix format of date-time examples

### DIFF
--- a/docs/openapi/components/schemas/Document.yaml
+++ b/docs/openapi/components/schemas/Document.yaml
@@ -17,7 +17,7 @@ properties:
   updatedAt:
     type: string
     format: date-time
-    example: 2021-03-11 13:34:33.885000
+    example: '2021-03-11 13:34:33.885000'
   entities:
     type: array
     items:

--- a/docs/openapi/components/schemas/ShallowDocument.yaml
+++ b/docs/openapi/components/schemas/ShallowDocument.yaml
@@ -17,4 +17,4 @@ properties:
   updatedAt:
     type: string
     format: date-time
-    example: 2021-03-04 13:12:30.612000
+    example: '2021-03-04 13:12:30.612000'

--- a/docs/openapi/components/schemas/ShallowProject.yaml
+++ b/docs/openapi/components/schemas/ShallowProject.yaml
@@ -17,4 +17,4 @@ properties:
   createdAt:
     type: string
     format: date-time
-    example: 2021-03-04 13:12:30.612000
+    example: '2021-03-04 13:12:30.612000'


### PR DESCRIPTION
Dates are parsed and reformatted according to RFC3339 if unquoted in YAML. To show them as-is in the docs they need to be quoted.
https://github.com/Redocly/redoc/issues/1293

Before:
![image](https://user-images.githubusercontent.com/9491603/142880234-58b65cb8-bd63-4416-8ef1-8bcdbb35a405.png)
After:
![image](https://user-images.githubusercontent.com/9491603/142880250-38ef6cbc-4c7c-4dc9-9e79-2fb10ebad2dc.png)

