### PR TITLE
BACKEND-1162 Add companyId to project response

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -30,7 +30,7 @@ info:
     where `<credentials>` is the base64-encoded string
     formed by `<application_id>:<application_key>`.
 
-  version: 0.0.3
+  version: 0.0.4
   title: Hypatos API
   license:
     name: Apache 2.0

--- a/docs/openapi/components/schemas/Project.yaml
+++ b/docs/openapi/components/schemas/Project.yaml
@@ -5,6 +5,7 @@ required:
   - lastModifiedAt
   - languages
   - ocrFeatures
+  - companyId
 properties:
   displayName:
     type: string
@@ -54,3 +55,7 @@ properties:
                 type: boolean
                 default: false
                 example: true
+  companyId:
+    type: string
+    example: 6295dcbc9db1ab740c3e2937
+


### PR DESCRIPTION
BACKEND-1162

Adds `companyId` to APIv1 project response.

Let's wait until this is deployed to prod: https://github.com/hypatos/studio-backend/pull/2511